### PR TITLE
Fix due dates showing a day early in negative-UTC timezones

### DIFF
--- a/home-upkeep/frontend/src/dates.ts
+++ b/home-upkeep/frontend/src/dates.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse a date-only value (e.g. "2026-06-11", as returned by the API for
+ * `due_date` or produced by an `<input type="date">`) into a local `Date` at
+ * midnight.
+ *
+ * `new Date("2026-06-11")` parses the string as UTC midnight, so in any
+ * timezone behind UTC the resulting `Date` falls on the previous calendar day.
+ * That made due dates show as Due/Overdue a day early (see issue #7). Building
+ * the `Date` from its components keeps it on the intended calendar day in the
+ * user's local timezone.
+ */
+export function parseDueDate(value: string): Date {
+  const [year, month, day] = value.slice(0, 10).split('-').map(Number) as [number, number, number];
+  return new Date(year, month - 1, day);
+}

--- a/home-upkeep/frontend/src/ui/App.tsx
+++ b/home-upkeep/frontend/src/ui/App.tsx
@@ -7,6 +7,7 @@ import { EditListDialog } from './EditListDialog';
 import { EditTaskDialog } from './EditTaskDialog';
 import { CreateListDialog } from './CreateListDialog';
 import { SnoozeDialog } from './SnoozeDialog';
+import { parseDueDate } from '../dates';
 
 function useTasks(selectedListId: number | undefined) {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -192,7 +193,7 @@ export function App() {
     setEditing(task);
     setEditTitle(task.title);
     setEditDescription(task.description ?? '');
-    setEditDueDate(task.due_date ? new Date(task.due_date).toISOString().slice(0, 10) : '');
+    setEditDueDate(task.due_date ? task.due_date.slice(0, 10) : '');
     setEditCompleted(task.completed);
     setEditCompletedAt(task.completed_at ? new Date(task.completed_at).toISOString().slice(0, 16) : '');
     setEditReschedPeriod(task.reschedule_period ?? '');
@@ -354,7 +355,7 @@ export function App() {
               const isDueOrOverdue = (t: Task) => {
                 if (t.completed) return false;
                 if (!t.due_date) return true; // include tasks with no due date
-                const d = new Date(t.due_date);
+                const d = parseDueDate(t.due_date);
                 d.setHours(0, 0, 0, 0);
                 return d.getTime() <= today.getTime();
               };
@@ -366,18 +367,18 @@ export function App() {
               const due = tasks
                 .filter(isDueOrOverdue)
                 .sort((a, b) => {
-                  const ad = a.due_date ? startOfDay(new Date(a.due_date)) : Infinity;
-                  const bd = b.due_date ? startOfDay(new Date(b.due_date)) : Infinity;
+                  const ad = a.due_date ? startOfDay(parseDueDate(a.due_date)) : Infinity;
+                  const bd = b.due_date ? startOfDay(parseDueDate(b.due_date)) : Infinity;
                   if (ad !== bd) return ad - bd; // by due date (day) ascending; no-due last
                   const ac = new Date(a.created_at).getTime();
                   const bc = new Date(b.created_at).getTime();
                   return ac - bc; // tie-break by created time ascending
                 });
               const upcoming = tasks
-                .filter((t) => !t.completed && t.due_date && startOfDay(new Date(t.due_date)) > today.getTime())
+                .filter((t) => !t.completed && t.due_date && startOfDay(parseDueDate(t.due_date)) > today.getTime())
                 .sort((a, b) => {
-                  const ad = startOfDay(new Date(a.due_date!));
-                  const bd = startOfDay(new Date(b.due_date!));
+                  const ad = startOfDay(parseDueDate(a.due_date!));
+                  const bd = startOfDay(parseDueDate(b.due_date!));
                   if (ad !== bd) return ad - bd;
                   const ac = new Date(a.created_at).getTime();
                   const bc = new Date(b.created_at).getTime();

--- a/home-upkeep/frontend/src/ui/EditTaskDialog.tsx
+++ b/home-upkeep/frontend/src/ui/EditTaskDialog.tsx
@@ -56,7 +56,7 @@ export function EditTaskDialog({
       title: title.trim() || undefined,
       description: description.trim() || undefined,
       completed: completed,
-      due_date: dueDate ? new Date(dueDate).toISOString() : null,
+      due_date: dueDate || null,
       reschedule_period: reschedPeriod || null,
       reschedule_base: reschedBase,
       completed_at: completedAt ? new Date(completedAt).toISOString() : null,

--- a/home-upkeep/frontend/src/ui/TaskForm.tsx
+++ b/home-upkeep/frontend/src/ui/TaskForm.tsx
@@ -21,7 +21,7 @@ export function TaskForm({ onSubmit, listId, onCancel }: TaskFormProps) {
           list_id: listId,
           title: title.trim(),
           description: description.trim() || undefined,
-          due_date: dueDate ? new Date(dueDate).toISOString() : undefined,
+          due_date: dueDate || undefined,
           reschedule_period: reschedPeriod || undefined,
         };
         if (!data.title) return;

--- a/home-upkeep/frontend/src/ui/TaskItem.tsx
+++ b/home-upkeep/frontend/src/ui/TaskItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Task } from '../api/client';
+import { parseDueDate } from '../dates';
 import { Icon } from '@mdi/react';
 import { mdiSleep, mdiPencil, mdiTrashCanOutline } from '@mdi/js';
 
@@ -13,7 +14,7 @@ interface TaskItemProps {
 
 export function TaskItem({ task, onToggle, onDelete, onEdit, onSnooze }: TaskItemProps) {
   // Determine if snooze button should be shown (only for due/overdue tasks)
-  const shouldShowSnooze = !task.completed && (!task.due_date || new Date(task.due_date) <= new Date());
+  const shouldShowSnooze = !task.completed && (!task.due_date || parseDueDate(task.due_date) <= new Date());
 
   return (
     <div className="task-item">
@@ -36,7 +37,7 @@ export function TaskItem({ task, onToggle, onDelete, onEdit, onSnooze }: TaskIte
                 <div className="mt-1 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
                 {task.due_date && (
                   <span className="badge-orange">
-                    Due {new Date(task.due_date).toLocaleDateString()}
+                    Due {parseDueDate(task.due_date).toLocaleDateString()}
                   </span>
                 )}
                 {task.completed_at && (
@@ -61,11 +62,11 @@ export function TaskItem({ task, onToggle, onDelete, onEdit, onSnooze }: TaskIte
                   // Check if task is due (no due date or due date is today or in the past)
                   const today = new Date();
                   today.setHours(0, 0, 0, 0); // Reset time to start of day for comparison
-                  const isTaskDue = !task.due_date || new Date(task.due_date) <= today;
+                  const isTaskDue = !task.due_date || parseDueDate(task.due_date) <= today;
 
                   // Check if task due date is in the same month and year as today
                   const isDueDateInCurrentMonth = task.due_date && (() => {
-                    const dueDate = new Date(task.due_date);
+                    const dueDate = parseDueDate(task.due_date);
                     const currentDate = new Date();
                     return dueDate.getMonth() === currentDate.getMonth() &&
                            dueDate.getFullYear() === currentDate.getFullYear();
@@ -75,7 +76,7 @@ export function TaskItem({ task, onToggle, onDelete, onEdit, onSnooze }: TaskIte
                   let isDueDateMonthProhibited = false;
                   let dueDateMonthName = '';
                   if (task.due_date) {
-                    const dueDate = new Date(task.due_date);
+                    const dueDate = parseDueDate(task.due_date);
                     const dueDateMonth = dueDate.getMonth() + 1;
                     isDueDateMonthProhibited = task.prohibited_months.includes(dueDateMonth);
                     dueDateMonthName = monthNames[dueDateMonth - 1] || '';


### PR DESCRIPTION
## Summary

Fixes #7 — due dates were displaying and counting as Due/Overdue one calendar day early for users in timezones behind UTC.

## Root cause

The backend stores `due_date` as a **date-only** value (`due_date: date` in `schemas.py`), so the API returns strings like `"2026-06-11"`. The frontend parsed these with `new Date("2026-06-11")`, which JavaScript interprets as **UTC midnight**. In any timezone behind UTC, that `Date` lands on the *previous* calendar day, so the task showed as due/overdue a day early.

## Changes

- Add `src/dates.ts` with a `parseDueDate()` helper that builds the `Date` from its components in **local** time.
- Use it everywhere a `due_date` is turned into a `Date` for display or comparison: the Due/Overdue + Upcoming grouping/sorting in `App.tsx`, and the date badge, snooze logic, and prohibited-month checks in `TaskItem.tsx`.
- Send the date-input value directly on write instead of round-tripping it through `new Date(...).toISOString()` (`TaskForm.tsx`, `EditTaskDialog.tsx`). Real timestamps like `completed_at` are left untouched.

## Verification

- `npm run typecheck` passes.
- Simulated `America/New_York` (UTC-4) in Node:
  - **Before:** displays `6/10/2026`, marked due/overdue on Jun 10 (the bug).
  - **After:** displays `6/11/2026`, correctly not due until Jun 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)