### PR TITLE
Fix add-on build failure from openssl package conflict

### DIFF
--- a/home-upkeep/Dockerfile
+++ b/home-upkeep/Dockerfile
@@ -52,7 +52,7 @@ COPY backend/ /app/backend/
 FROM ${BUILD_FROM}
 
 # Install Python runtime dependencies only
-RUN apk add --no-cache python3 py3-pip libffi openssl bash
+RUN apk add --no-cache python3 py3-pip libffi bash
 
 # Install nginx
 RUN apk --no-cache add nginx && mkdir -p /run/nginx


### PR DESCRIPTION
## Summary

Building the add-on currently fails in the final image stage with:

```
ERROR: unable to select packages:
  libcrypto3-3.5.4-r0:
    breaks: openssl-3.5.7-r0[libcrypto3=3.5.7-r0]
  libssl3-3.5.4-r0:
    breaks: openssl-3.5.7-r0[libssl3=3.5.7-r0]
```

## Cause

The runtime stage runs `apk add ... openssl`. The add-on base image (`ghcr.io/hassio-addons/base/*:18.2.0`) pins `libssl3`/`libcrypto3` at `3.5.4-r0`, but the Alpine repo has since moved to `openssl 3.5.7-r0`, which requires the matching `3.5.7` libs. apk can't reconcile the newer `openssl` with the held `3.5.4` libraries, so the build aborts. It built cleanly when the published image was first created and has only broken as the upstream Alpine repo drifted.

## Fix

Drop the unused `openssl` package from the runtime stage:

- The `openssl` CLI isn't referenced anywhere in the add-on (rootfs scripts, nginx config, backend).
- `python3` only needs the `libssl3` shared library, which is already present in the base image.

This is independent of #8 (the due-date timezone fix); it just unblocks building the add-on from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)